### PR TITLE
app and bin server dart

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,10 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+@app.route('/')
+def hello():
+    return "Hello from Python!"
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=8080)

--- a/bin/server.dart
+++ b/bin/server.dart
@@ -1,0 +1,10 @@
+import 'dart:io';
+
+void main() async {
+  var server = await HttpServer.bind(InternetAddress.anyIPv4, 8080);
+  print('Server running on port 8080');
+  await for (HttpRequest request in server) {
+    request.response.write('Hello, Cloud Run!');
+    await request.response.close();
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add simple Python Flask and Dart HTTP servers responding at '/' on port 8080.
> 
> - **Servers**:
>   - **Python (Flask)**: New `app.py` with `'/'` route returning `"Hello from Python!"`; runs on `0.0.0.0:8080`.
>   - **Dart (HttpServer)**: New `bin/server.dart` serving `"Hello, Cloud Run!"` on port `8080`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 359873e36bba3d783683c21524f5043dd0021442. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->